### PR TITLE
optimize data upload - create last trade data API

### DIFF
--- a/data/cli.py
+++ b/data/cli.py
@@ -26,10 +26,12 @@ def core():
 
 
 @core.command()
-def upload():
+@click.option("--all", default="0", help="Import ALL trades?")
+def upload(all):
     from upload_to_portfolio_manager import execute
 
-    execute()
+    import_all: bool = all != "0"
+    execute(import_all)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To make the data upload process faster, we need to know when the last executed trade took place.

We can then use this datetime stamp to then downsize the data we import.